### PR TITLE
add a make command 'build-nc' to force building w/o cache

### DIFF
--- a/8/8.8/Makefile
+++ b/8/8.8/Makefile
@@ -28,6 +28,13 @@ build:
 		--build-arg DRUPAL_VER=$(DRUPAL_VER) \
 		./
 
+build-nc:
+	docker build -t $(REPO):$(TAG) \
+		--build-arg BASE_IMAGE_TAG=$(BASE_IMAGE_TAG) \
+		--build-arg DRUPAL_VER=$(DRUPAL_VER) \
+		--no-cache \
+		./
+
 test:
 	cd ./tests && IMAGE=$(REPO):$(TAG) ./run.sh
 

--- a/8/8.8/Makefile
+++ b/8/8.8/Makefile
@@ -32,7 +32,7 @@ build-nc:
 	docker build -t $(REPO):$(TAG) \
 		--build-arg BASE_IMAGE_TAG=$(BASE_IMAGE_TAG) \
 		--build-arg DRUPAL_VER=$(DRUPAL_VER) \
-		--no-cache \
+		--no-cache --pull \
 		./
 
 test:

--- a/8/8.9/Makefile
+++ b/8/8.9/Makefile
@@ -28,6 +28,13 @@ build:
 		--build-arg DRUPAL_VER=$(DRUPAL_VER) \
 		./
 
+build-nc:
+	docker build -t $(REPO):$(TAG) \
+		--build-arg BASE_IMAGE_TAG=$(BASE_IMAGE_TAG) \
+		--build-arg DRUPAL_VER=$(DRUPAL_VER) \
+		--no-cache \
+		./
+
 test:
 	cd ./tests && IMAGE=$(REPO):$(TAG) ./run.sh
 

--- a/8/8.9/Makefile
+++ b/8/8.9/Makefile
@@ -32,7 +32,7 @@ build-nc:
 	docker build -t $(REPO):$(TAG) \
 		--build-arg BASE_IMAGE_TAG=$(BASE_IMAGE_TAG) \
 		--build-arg DRUPAL_VER=$(DRUPAL_VER) \
-		--no-cache \
+		--no-cache --pull \
 		./
 
 test:

--- a/9/9.0/Makefile
+++ b/9/9.0/Makefile
@@ -28,6 +28,13 @@ build:
 		--build-arg DRUPAL_VER=$(DRUPAL_VER) \
 		./
 
+build-nc:
+	docker build -t $(REPO):$(TAG) \
+		--build-arg BASE_IMAGE_TAG=$(BASE_IMAGE_TAG) \
+		--build-arg DRUPAL_VER=$(DRUPAL_VER) \
+		--no-cache \
+		./
+
 test:
 	cd ./tests && IMAGE=$(REPO):$(TAG) ./run.sh
 

--- a/9/9.0/Makefile
+++ b/9/9.0/Makefile
@@ -32,7 +32,7 @@ build-nc:
 	docker build -t $(REPO):$(TAG) \
 		--build-arg BASE_IMAGE_TAG=$(BASE_IMAGE_TAG) \
 		--build-arg DRUPAL_VER=$(DRUPAL_VER) \
-		--no-cache \
+		--no-cache --pull \
 		./
 
 test:

--- a/9/9.1/Makefile
+++ b/9/9.1/Makefile
@@ -28,6 +28,13 @@ build:
 		--build-arg DRUPAL_VER=$(DRUPAL_VER) \
 		./
 
+build-nc:
+	docker build -t $(REPO):$(TAG) \
+		--build-arg BASE_IMAGE_TAG=$(BASE_IMAGE_TAG) \
+		--build-arg DRUPAL_VER=$(DRUPAL_VER) \
+		--no-cache \
+		./
+
 test:
 	cd ./tests && IMAGE=$(REPO):$(TAG) ./run.sh
 

--- a/9/9.1/Makefile
+++ b/9/9.1/Makefile
@@ -32,7 +32,7 @@ build-nc:
 	docker build -t $(REPO):$(TAG) \
 		--build-arg BASE_IMAGE_TAG=$(BASE_IMAGE_TAG) \
 		--build-arg DRUPAL_VER=$(DRUPAL_VER) \
-		--no-cache \
+		--no-cache --pull \
 		./
 
 test:


### PR DESCRIPTION
add a new make command on all images `build-nc` to build images without caches