### PR TITLE
Update Images to latests Drupal base Images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ services:
 
 matrix:
   include:
-    - name: Drupal 8.8.9
+    - name: Drupal 8.8.x
       env: DOCKER_TAG="8.8"
-    - name: Drupal 8.9.1
+    - name: Drupal 8.9.x
       env: DOCKER_TAG="8.9"
-    - name: Drupal 9.0.1
+    - name: Drupal 9.0.x
       env: DOCKER_TAG="9.0"
     - name: Drupal 9.1-dev
       env: DOCKER_TAG="9.1"

--- a/8/8.8/Dockerfile
+++ b/8/8.8/Dockerfile
@@ -5,7 +5,7 @@ ARG DRUPAL_VER
 
 ENV DRUPAL_VER="${DRUPAL_VER}"
 
-WORKDIR /var/www/html
+WORKDIR /opt/drupal
 
 # Install git and zip library.
 # Necessary for some composer operations.
@@ -25,18 +25,18 @@ RUN curl -OL https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait
 
 # Add Composer vendors directory to the path.
 # So we would be able to run binary without specifying ./vendor/bin/.
-ENV PATH /var/www/html/vendor/bin:$PATH
+ENV PATH /opt/drupal/vendor/bin:$PATH
 
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php && \
     mv composer.phar /usr/local/bin/composer
 
 # Install Drupal Dev dependencies such as PHPUnit, Behat-Mink, ...
-RUN COMPOSER_MEMORY_LIMIT=-1 composer require --dev drupal/core-dev:^${DRUPAL_VER}
+RUN COMPOSER_MEMORY_LIMIT=-1 composer require --dev drupal/core-dev:~${DRUPAL_VER}
 
 # Install Drush.
 # Drush will be heavily use to setup a working Drupal environment.
-RUN COMPOSER_MEMORY_LIMIT=-1 composer require drush/drush:^10.1.1 symfony/process:^4.4.9
+RUN COMPOSER_MEMORY_LIMIT=-1 composer require drush/drush:^10.1.1
 
 # Install Drush Launcher
 # So we would be able the run drush from any places without being in the Drupal web directory.
@@ -48,4 +48,4 @@ RUN curl -OL https://github.com/drush-ops/drush-launcher/releases/latest/downloa
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Copy a default template for PHPUnit testing.
-COPY templates/phpunit.xml /var/www/html/phpunit.xml
+COPY templates/phpunit.xml /opt/drupal/web/phpunit.xml

--- a/8/8.8/Dockerfile
+++ b/8/8.8/Dockerfile
@@ -36,7 +36,7 @@ RUN COMPOSER_MEMORY_LIMIT=-1 composer require --dev drupal/core-dev:^${DRUPAL_VE
 
 # Install Drush.
 # Drush will be heavily use to setup a working Drupal environment.
-RUN COMPOSER_MEMORY_LIMIT=-1 composer require drush/drush:^10.1.1
+RUN COMPOSER_MEMORY_LIMIT=-1 composer require drush/drush:^10.1.1 symfony/process:^4.4.9
 
 # Install Drush Launcher
 # So we would be able the run drush from any places without being in the Drupal web directory.

--- a/8/8.8/Dockerfile
+++ b/8/8.8/Dockerfile
@@ -23,14 +23,6 @@ RUN curl -OL https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait
     chmod +x wait-for-it.sh && \
     mv wait-for-it.sh /usr/local/bin/wait-for-it
 
-# Add Composer vendors directory to the path.
-# So we would be able to run binary without specifying ./vendor/bin/.
-ENV PATH /opt/drupal/vendor/bin:$PATH
-
-# Install Composer.
-RUN curl -sS https://getcomposer.org/installer | php && \
-    mv composer.phar /usr/local/bin/composer
-
 # Install Drupal Dev dependencies such as PHPUnit, Behat-Mink, ...
 RUN COMPOSER_MEMORY_LIMIT=-1 composer require --dev drupal/core-dev:~${DRUPAL_VER}
 

--- a/8/8.8/templates/phpunit.xml
+++ b/8/8.8/templates/phpunit.xml
@@ -8,15 +8,8 @@
 <phpunit bootstrap="core/tests/bootstrap.php" colors="true"
          beStrictAboutTestsThatDoNotTestAnything="true"
          beStrictAboutOutputDuringTests="true"
-         beStrictAboutChangesToGlobalState="true">
-<!-- TODO set printerClass="\Drupal\Tests\Listeners\HtmlOutputPrinter" once
- https://youtrack.jetbrains.com/issue/WI-24808 is resolved. Drupal provides a
- result printer that links to the html output results for functional tests.
- Unfortunately, this breaks the output of PHPStorm's PHPUnit runner. However, if
- using the command line you can add
- - -printer="\Drupal\Tests\Listeners\HtmlOutputPrinter" to use it (note there
- should be no spaces between the hyphens).
--->
+         beStrictAboutChangesToGlobalState="true"
+         printerClass="\Drupal\Tests\Listeners\HtmlOutputPrinter">
   <php>
     <!-- Set error reporting to E_ALL. -->
     <ini name="error_reporting" value="32767"/>
@@ -24,15 +17,25 @@
     <ini name="memory_limit" value="-1"/>
     <!-- Example SIMPLETEST_BASE_URL value: http://localhost -->
     <env name="SIMPLETEST_BASE_URL" value="http://drupal"/>
+    <!-- Example SIMPLETEST_DB value: mysql://username:password@localhost/databasename#table_prefix -->
     <env name="SIMPLETEST_DB" value="mysql://drupal:drupal@db/drupal"/>
-    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value="/var/wtww/html/sites/default/files/simpletest/browser_output"/>
-    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu","--headless"]}}, "http://chrome:9515"]'/>
+    <!-- Example BROWSERTEST_OUTPUT_DIRECTORY value: /path/to/webroot/sites/simpletest/browser_output -->
+    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value="/opt/drupal/web/sites/default/files/simpletest/browser_output"/>
+    <!-- To have browsertest output use an alternative base URL. For example if
+     SIMPLETEST_BASE_URL is an internal DDEV URL, you can set this to the
+     external DDev URL so you can follow the links directly.
+    -->
+    <env name="BROWSERTEST_OUTPUT_BASE_URL" value=""/>
     <!-- To disable deprecation testing completely uncomment the next line. -->
     <!-- <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/> -->
     <!-- Example for changing the driver class for mink tests MINK_DRIVER_CLASS value: 'Drupal\FunctionalJavascriptTests\DrupalSelenium2Driver' -->
+    <env name="MINK_DRIVER_CLASS" value=''/>
     <!-- Example for changing the driver args to mink tests MINK_DRIVER_ARGS value: '["http://127.0.0.1:8510"]' -->
+    <env name="MINK_DRIVER_ARGS" value=''/>
     <!-- Example for changing the driver args to phantomjs tests MINK_DRIVER_ARGS_PHANTOMJS value: '["http://127.0.0.1:8510"]' -->
-    <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["firefox", null, "http://localhost:4444/wd/hub"]' -->
+    <env name="MINK_DRIVER_ARGS_PHANTOMJS" value=''/>
+    <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["chrome", { "chromeOptions": { "w3c": false } }, "http://localhost:4444/wd/hub"]' For using the Firefox browser, replace "chrome" with "firefox" -->
+    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu","--headless"]}}, "http://chrome:9515"]'/>
   </php>
   <testsuites>
     <testsuite name="unit">
@@ -46,6 +49,9 @@
     </testsuite>
     <testsuite name="functional-javascript">
       <file>./core/tests/TestSuites/FunctionalJavascriptTestSuite.php</file>
+    </testsuite>
+    <testsuite name="build">
+      <file>./core/tests/TestSuites/BuildTestSuite.php</file>
     </testsuite>
   </testsuites>
   <listeners>
@@ -61,14 +67,25 @@
       <directory>./core/includes</directory>
       <directory>./core/lib</directory>
       <directory>./core/modules</directory>
+      <!-- Extensions can have their own test directories, so exclude those. -->
+      <exclude>
+        <directory>./core/modules/*/src/Tests</directory>
+        <directory>./core/modules/*/tests</directory>
+      </exclude>
       <directory>./modules</directory>
+      <exclude>
+        <directory>./modules/*/src/Tests</directory>
+        <directory>./modules/*/tests</directory>
+        <directory>./modules/*/*/src/Tests</directory>
+        <directory>./modules/*/*/tests</directory>
+      </exclude>
       <directory>./sites</directory>
       <!-- By definition test classes have no tests. -->
       <exclude>
         <directory suffix="Test.php">./</directory>
         <directory suffix="TestBase.php">./</directory>
       </exclude>
-     </whitelist>
+    </whitelist>
   </filter>
   <!-- Logging for coverage reports. -->
   <logging>

--- a/8/8.8/tests/run.sh
+++ b/8/8.8/tests/run.sh
@@ -12,9 +12,9 @@ cid="$(
 )"
 trap "docker rm -vf ${cid} > /dev/null" EXIT
 
-docker exec "${cid}" drush status | grep -q 'Drupal root    : /var/www/html'
-docker exec "${cid}" drush status | grep -q 'Drupal version : 8.8.8'
+docker exec "${cid}" drush status | grep -q 'Drupal root    : /opt/drupal/web'
+docker exec "${cid}" drush status | grep -q 'Drupal version : 8.8.'
 docker exec "${cid}" drush status | grep -q 'Drush version  : 10.'
-docker exec "${cid}" which phpunit | grep -q '/var/www/html/vendor/bin/phpunit'
+docker exec "${cid}" which phpunit | grep -q '/opt/drupal/vendor/bin/phpunit'
 docker exec "${cid}" phpunit --version | grep -q 'PHPUnit 7.5.20 by Sebastian Bergmann and contributors.'
 echo "OK"

--- a/8/8.9/Dockerfile
+++ b/8/8.9/Dockerfile
@@ -23,14 +23,6 @@ RUN curl -OL https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait
     chmod +x wait-for-it.sh && \
     mv wait-for-it.sh /usr/local/bin/wait-for-it
 
-# Add Composer vendors directory to the path.
-# So we would be able to run binary without specifying ./vendor/bin/.
-ENV PATH /opt/drupal/vendor/bin:$PATH
-
-# Install Composer.
-RUN curl -sS https://getcomposer.org/installer | php && \
-    mv composer.phar /usr/local/bin/composer
-
 # Install Drupal Dev dependencies such as PHPUnit, Behat-Mink, ...
 RUN COMPOSER_MEMORY_LIMIT=-1 composer require --dev drupal/core-dev:~${DRUPAL_VER}
 

--- a/8/8.9/Dockerfile
+++ b/8/8.9/Dockerfile
@@ -5,7 +5,7 @@ ARG DRUPAL_VER
 
 ENV DRUPAL_VER="${DRUPAL_VER}"
 
-WORKDIR /var/www/html
+WORKDIR /opt/drupal
 
 # Install git and zip library.
 # Necessary for some composer operations.
@@ -25,14 +25,14 @@ RUN curl -OL https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait
 
 # Add Composer vendors directory to the path.
 # So we would be able to run binary without specifying ./vendor/bin/.
-ENV PATH /var/www/html/vendor/bin:$PATH
+ENV PATH /opt/drupal/vendor/bin:$PATH
 
 # Install Composer.
 RUN curl -sS https://getcomposer.org/installer | php && \
     mv composer.phar /usr/local/bin/composer
 
 # Install Drupal Dev dependencies such as PHPUnit, Behat-Mink, ...
-RUN COMPOSER_MEMORY_LIMIT=-1 composer require --dev drupal/core-dev:^${DRUPAL_VER}
+RUN COMPOSER_MEMORY_LIMIT=-1 composer require --dev drupal/core-dev:~${DRUPAL_VER}
 
 # Install Drush.
 # Drush will be heavily use to setup a working Drupal environment.
@@ -48,4 +48,4 @@ RUN curl -OL https://github.com/drush-ops/drush-launcher/releases/latest/downloa
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Copy a default template for PHPUnit testing.
-COPY templates/phpunit.xml /var/www/html/phpunit.xml
+COPY templates/phpunit.xml /opt/drupal/web/phpunit.xml

--- a/8/8.9/Makefile
+++ b/8/8.9/Makefile
@@ -1,7 +1,7 @@
-DRUPAL_VER ?= 8.9.1
+DRUPAL_VER ?= 8.9.3
 DRUPAL_VER_MAJOR ?= $(shell echo "${DRUPAL_VER}" | grep -oE '^[0-9]+\.[0-9]+')
 
-BASE_IMAGE_TAG = 8.9.1
+BASE_IMAGE_TAG = 8.9.3
 
 REPO = wengerk/drupal-for-contrib
 NAME = drupal-$(DRUPAL_VER_MAJOR)

--- a/8/8.9/templates/phpunit.xml
+++ b/8/8.9/templates/phpunit.xml
@@ -8,15 +8,8 @@
 <phpunit bootstrap="core/tests/bootstrap.php" colors="true"
          beStrictAboutTestsThatDoNotTestAnything="true"
          beStrictAboutOutputDuringTests="true"
-         beStrictAboutChangesToGlobalState="true">
-<!-- TODO set printerClass="\Drupal\Tests\Listeners\HtmlOutputPrinter" once
- https://youtrack.jetbrains.com/issue/WI-24808 is resolved. Drupal provides a
- result printer that links to the html output results for functional tests.
- Unfortunately, this breaks the output of PHPStorm's PHPUnit runner. However, if
- using the command line you can add
- - -printer="\Drupal\Tests\Listeners\HtmlOutputPrinter" to use it (note there
- should be no spaces between the hyphens).
--->
+         beStrictAboutChangesToGlobalState="true"
+         printerClass="\Drupal\Tests\Listeners\HtmlOutputPrinter">
   <php>
     <!-- Set error reporting to E_ALL. -->
     <ini name="error_reporting" value="32767"/>
@@ -24,15 +17,25 @@
     <ini name="memory_limit" value="-1"/>
     <!-- Example SIMPLETEST_BASE_URL value: http://localhost -->
     <env name="SIMPLETEST_BASE_URL" value="http://drupal"/>
+    <!-- Example SIMPLETEST_DB value: mysql://username:password@localhost/databasename#table_prefix -->
     <env name="SIMPLETEST_DB" value="mysql://drupal:drupal@db/drupal"/>
-    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value="/var/wtww/html/sites/default/files/simpletest/browser_output"/>
-    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu","--headless"]}}, "http://chrome:9515"]'/>
+    <!-- Example BROWSERTEST_OUTPUT_DIRECTORY value: /path/to/webroot/sites/simpletest/browser_output -->
+    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value="/opt/drupal/web/sites/default/files/simpletest/browser_output"/>
+    <!-- To have browsertest output use an alternative base URL. For example if
+     SIMPLETEST_BASE_URL is an internal DDEV URL, you can set this to the
+     external DDev URL so you can follow the links directly.
+    -->
+    <env name="BROWSERTEST_OUTPUT_BASE_URL" value=""/>
     <!-- To disable deprecation testing completely uncomment the next line. -->
     <!-- <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/> -->
     <!-- Example for changing the driver class for mink tests MINK_DRIVER_CLASS value: 'Drupal\FunctionalJavascriptTests\DrupalSelenium2Driver' -->
+    <env name="MINK_DRIVER_CLASS" value=''/>
     <!-- Example for changing the driver args to mink tests MINK_DRIVER_ARGS value: '["http://127.0.0.1:8510"]' -->
+    <env name="MINK_DRIVER_ARGS" value=''/>
     <!-- Example for changing the driver args to phantomjs tests MINK_DRIVER_ARGS_PHANTOMJS value: '["http://127.0.0.1:8510"]' -->
-    <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["firefox", null, "http://localhost:4444/wd/hub"]' -->
+    <env name="MINK_DRIVER_ARGS_PHANTOMJS" value=''/>
+    <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["chrome", { "chromeOptions": { "w3c": false } }, "http://localhost:4444/wd/hub"]' For using the Firefox browser, replace "chrome" with "firefox" -->
+    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu","--headless"]}}, "http://chrome:9515"]'/>
   </php>
   <testsuites>
     <testsuite name="unit">
@@ -46,6 +49,9 @@
     </testsuite>
     <testsuite name="functional-javascript">
       <file>./core/tests/TestSuites/FunctionalJavascriptTestSuite.php</file>
+    </testsuite>
+    <testsuite name="build">
+      <file>./core/tests/TestSuites/BuildTestSuite.php</file>
     </testsuite>
   </testsuites>
   <listeners>
@@ -61,14 +67,25 @@
       <directory>./core/includes</directory>
       <directory>./core/lib</directory>
       <directory>./core/modules</directory>
+      <!-- Extensions can have their own test directories, so exclude those. -->
+      <exclude>
+        <directory>./core/modules/*/src/Tests</directory>
+        <directory>./core/modules/*/tests</directory>
+      </exclude>
       <directory>./modules</directory>
+      <exclude>
+        <directory>./modules/*/src/Tests</directory>
+        <directory>./modules/*/tests</directory>
+        <directory>./modules/*/*/src/Tests</directory>
+        <directory>./modules/*/*/tests</directory>
+      </exclude>
       <directory>./sites</directory>
       <!-- By definition test classes have no tests. -->
       <exclude>
         <directory suffix="Test.php">./</directory>
         <directory suffix="TestBase.php">./</directory>
       </exclude>
-     </whitelist>
+    </whitelist>
   </filter>
   <!-- Logging for coverage reports. -->
   <logging>

--- a/8/8.9/tests/run.sh
+++ b/8/8.9/tests/run.sh
@@ -12,9 +12,9 @@ cid="$(
 )"
 trap "docker rm -vf ${cid} > /dev/null" EXIT
 
-docker exec "${cid}" drush status | grep -q 'Drupal root    : /var/www/html'
-docker exec "${cid}" drush status | grep -q 'Drupal version : 8.9.1'
+docker exec "${cid}" drush status | grep -q 'Drupal root    : /opt/drupal/web'
+docker exec "${cid}" drush status | grep -q 'Drupal version : 8.9.'
 docker exec "${cid}" drush status | grep -q 'Drush version  : 10.'
-docker exec "${cid}" which phpunit | grep -q '/var/www/html/vendor/bin/phpunit'
+docker exec "${cid}" which phpunit | grep -q '/opt/drupal/vendor/bin/phpunit'
 docker exec "${cid}" phpunit --version | grep -q 'PHPUnit 7.5.20 by Sebastian Bergmann and contributors.'
 echo "OK"

--- a/9/9.0/Dockerfile
+++ b/9/9.0/Dockerfile
@@ -23,12 +23,8 @@ RUN curl -OL https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait
     chmod +x wait-for-it.sh && \
     mv wait-for-it.sh /usr/local/bin/wait-for-it
 
-# Add Composer vendors directory to the path.
-# So we would be able to run binary without specifying ./vendor/bin/.
-ENV PATH /opt/drupal/vendor/bin:$PATH
-
 # Install Drupal Dev dependencies such as PHPUnit, Behat-Mink, ...
-RUN COMPOSER_MEMORY_LIMIT=-1 composer require --dev drupal/core-dev:^${DRUPAL_VER}
+RUN COMPOSER_MEMORY_LIMIT=-1 composer require --dev drupal/core-dev:~${DRUPAL_VER}
 
 # Install Drush.
 # Drush will be heavily use to setup a working Drupal environment.

--- a/9/9.0/Dockerfile
+++ b/9/9.0/Dockerfile
@@ -44,4 +44,4 @@ RUN curl -OL https://github.com/drush-ops/drush-launcher/releases/latest/downloa
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Copy a default template for PHPUnit testing.
-COPY templates/phpunit.xml /var/www/html/phpunit.xml
+COPY templates/phpunit.xml /opt/drupal/web/phpunit.xml

--- a/9/9.0/templates/phpunit.xml
+++ b/9/9.0/templates/phpunit.xml
@@ -8,15 +8,10 @@
 <phpunit bootstrap="core/tests/bootstrap.php" colors="true"
          beStrictAboutTestsThatDoNotTestAnything="true"
          beStrictAboutOutputDuringTests="true"
-         beStrictAboutChangesToGlobalState="true">
-<!-- TODO set printerClass="\Drupal\Tests\Listeners\HtmlOutputPrinter" once
- https://youtrack.jetbrains.com/issue/WI-24808 is resolved. Drupal provides a
- result printer that links to the html output results for functional tests.
- Unfortunately, this breaks the output of PHPStorm's PHPUnit runner. However, if
- using the command line you can add
- - -printer="\Drupal\Tests\Listeners\HtmlOutputPrinter" to use it (note there
- should be no spaces between the hyphens).
--->
+         beStrictAboutChangesToGlobalState="true"
+         failOnWarning="true"
+         printerClass="\Drupal\Tests\Listeners\HtmlOutputPrinter"
+         cacheResult="false">
   <php>
     <!-- Set error reporting to E_ALL. -->
     <ini name="error_reporting" value="32767"/>
@@ -24,15 +19,23 @@
     <ini name="memory_limit" value="-1"/>
     <!-- Example SIMPLETEST_BASE_URL value: http://localhost -->
     <env name="SIMPLETEST_BASE_URL" value="http://drupal"/>
+    <!-- Example SIMPLETEST_DB value: mysql://username:password@localhost/databasename#table_prefix -->
     <env name="SIMPLETEST_DB" value="mysql://drupal:drupal@db/drupal"/>
-    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value="/var/wtww/html/sites/default/files/simpletest/browser_output"/>
-    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu","--headless"]}}, "http://chrome:9515"]'/>
+    <!-- Example BROWSERTEST_OUTPUT_DIRECTORY value: /path/to/webroot/sites/simpletest/browser_output -->
+    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value="/opt/drupal/web/sites/default/files/simpletest/browser_output"/>
+    <!-- To have browsertest output use an alternative base URL. For example if
+     SIMPLETEST_BASE_URL is an internal DDEV URL, you can set this to the
+     external DDev URL so you can follow the links directly.
+    -->
+    <env name="BROWSERTEST_OUTPUT_BASE_URL" value=""/>
     <!-- To disable deprecation testing completely uncomment the next line. -->
     <!-- <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/> -->
     <!-- Example for changing the driver class for mink tests MINK_DRIVER_CLASS value: 'Drupal\FunctionalJavascriptTests\DrupalSelenium2Driver' -->
+    <env name="MINK_DRIVER_CLASS" value=''/>
     <!-- Example for changing the driver args to mink tests MINK_DRIVER_ARGS value: '["http://127.0.0.1:8510"]' -->
-    <!-- Example for changing the driver args to phantomjs tests MINK_DRIVER_ARGS_PHANTOMJS value: '["http://127.0.0.1:8510"]' -->
-    <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["firefox", null, "http://localhost:4444/wd/hub"]' -->
+    <env name="MINK_DRIVER_ARGS" value=''/>
+    <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["chrome", { "chromeOptions": { "w3c": false } }, "http://localhost:4444/wd/hub"]' For using the Firefox browser, replace "chrome" with "firefox" -->
+    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu","--headless"]}}, "http://chrome:9515"]'/>
   </php>
   <testsuites>
     <testsuite name="unit">
@@ -46,6 +49,9 @@
     </testsuite>
     <testsuite name="functional-javascript">
       <file>./core/tests/TestSuites/FunctionalJavascriptTestSuite.php</file>
+    </testsuite>
+    <testsuite name="build">
+      <file>./core/tests/TestSuites/BuildTestSuite.php</file>
     </testsuite>
   </testsuites>
   <listeners>
@@ -61,14 +67,25 @@
       <directory>./core/includes</directory>
       <directory>./core/lib</directory>
       <directory>./core/modules</directory>
+      <!-- Extensions can have their own test directories, so exclude those. -->
+      <exclude>
+        <directory>./core/modules/*/src/Tests</directory>
+        <directory>./core/modules/*/tests</directory>
+      </exclude>
       <directory>./modules</directory>
+      <exclude>
+        <directory>./modules/*/src/Tests</directory>
+        <directory>./modules/*/tests</directory>
+        <directory>./modules/*/*/src/Tests</directory>
+        <directory>./modules/*/*/tests</directory>
+      </exclude>
       <directory>./sites</directory>
       <!-- By definition test classes have no tests. -->
       <exclude>
         <directory suffix="Test.php">./</directory>
         <directory suffix="TestBase.php">./</directory>
       </exclude>
-     </whitelist>
+    </whitelist>
   </filter>
   <!-- Logging for coverage reports. -->
   <logging>

--- a/9/9.1/Dockerfile
+++ b/9/9.1/Dockerfile
@@ -23,10 +23,6 @@ RUN curl -OL https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait
     chmod +x wait-for-it.sh && \
     mv wait-for-it.sh /usr/local/bin/wait-for-it
 
-# Add Composer vendors directory to the path.
-# So we would be able to run binary without specifying ./vendor/bin/.
-ENV PATH /opt/drupal/vendor/bin:$PATH
-
 # Install Drush.
 # Drush will be heavily use to setup a working Drupal environment.
 RUN COMPOSER_MEMORY_LIMIT=-1 composer require drush/drush:^10.1.1

--- a/9/9.1/Dockerfile
+++ b/9/9.1/Dockerfile
@@ -49,4 +49,4 @@ RUN COMPOSER_MEMORY_LIMIT=-1 composer update
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Copy a default template for PHPUnit testing.
-COPY templates/phpunit.xml /var/www/html/phpunit.xml
+COPY templates/phpunit.xml /opt/drupal/web/phpunit.xml

--- a/9/9.1/templates/phpunit.xml
+++ b/9/9.1/templates/phpunit.xml
@@ -8,15 +8,10 @@
 <phpunit bootstrap="core/tests/bootstrap.php" colors="true"
          beStrictAboutTestsThatDoNotTestAnything="true"
          beStrictAboutOutputDuringTests="true"
-         beStrictAboutChangesToGlobalState="true">
-<!-- TODO set printerClass="\Drupal\Tests\Listeners\HtmlOutputPrinter" once
- https://youtrack.jetbrains.com/issue/WI-24808 is resolved. Drupal provides a
- result printer that links to the html output results for functional tests.
- Unfortunately, this breaks the output of PHPStorm's PHPUnit runner. However, if
- using the command line you can add
- - -printer="\Drupal\Tests\Listeners\HtmlOutputPrinter" to use it (note there
- should be no spaces between the hyphens).
--->
+         beStrictAboutChangesToGlobalState="true"
+         failOnWarning="true"
+         printerClass="\Drupal\Tests\Listeners\HtmlOutputPrinter"
+         cacheResult="false">
   <php>
     <!-- Set error reporting to E_ALL. -->
     <ini name="error_reporting" value="32767"/>
@@ -24,15 +19,23 @@
     <ini name="memory_limit" value="-1"/>
     <!-- Example SIMPLETEST_BASE_URL value: http://localhost -->
     <env name="SIMPLETEST_BASE_URL" value="http://drupal"/>
+    <!-- Example SIMPLETEST_DB value: mysql://username:password@localhost/databasename#table_prefix -->
     <env name="SIMPLETEST_DB" value="mysql://drupal:drupal@db/drupal"/>
-    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value="/var/wtww/html/sites/default/files/simpletest/browser_output"/>
-    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu","--headless"]}}, "http://chrome:9515"]'/>
+    <!-- Example BROWSERTEST_OUTPUT_DIRECTORY value: /path/to/webroot/sites/simpletest/browser_output -->
+    <env name="BROWSERTEST_OUTPUT_DIRECTORY" value="/opt/drupal/web/sites/default/files/simpletest/browser_output"/>
+    <!-- To have browsertest output use an alternative base URL. For example if
+     SIMPLETEST_BASE_URL is an internal DDEV URL, you can set this to the
+     external DDev URL so you can follow the links directly.
+    -->
+    <env name="BROWSERTEST_OUTPUT_BASE_URL" value=""/>
     <!-- To disable deprecation testing completely uncomment the next line. -->
     <!-- <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/> -->
     <!-- Example for changing the driver class for mink tests MINK_DRIVER_CLASS value: 'Drupal\FunctionalJavascriptTests\DrupalSelenium2Driver' -->
+    <env name="MINK_DRIVER_CLASS" value=''/>
     <!-- Example for changing the driver args to mink tests MINK_DRIVER_ARGS value: '["http://127.0.0.1:8510"]' -->
-    <!-- Example for changing the driver args to phantomjs tests MINK_DRIVER_ARGS_PHANTOMJS value: '["http://127.0.0.1:8510"]' -->
-    <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["firefox", null, "http://localhost:4444/wd/hub"]' -->
+    <env name="MINK_DRIVER_ARGS" value=''/>
+    <!-- Example for changing the driver args to webdriver tests MINK_DRIVER_ARGS_WEBDRIVER value: '["chrome", { "chromeOptions": { "w3c": false } }, "http://localhost:4444/wd/hub"]' For using the Firefox browser, replace "chrome" with "firefox" -->
+    <env name="MINK_DRIVER_ARGS_WEBDRIVER" value='["chrome", {"browserName":"chrome","chromeOptions":{"args":["--disable-gpu","--headless"]}}, "http://chrome:9515"]'/>
   </php>
   <testsuites>
     <testsuite name="unit">
@@ -46,6 +49,9 @@
     </testsuite>
     <testsuite name="functional-javascript">
       <file>./core/tests/TestSuites/FunctionalJavascriptTestSuite.php</file>
+    </testsuite>
+    <testsuite name="build">
+      <file>./core/tests/TestSuites/BuildTestSuite.php</file>
     </testsuite>
   </testsuites>
   <listeners>
@@ -61,14 +67,25 @@
       <directory>./core/includes</directory>
       <directory>./core/lib</directory>
       <directory>./core/modules</directory>
+      <!-- Extensions can have their own test directories, so exclude those. -->
+      <exclude>
+        <directory>./core/modules/*/src/Tests</directory>
+        <directory>./core/modules/*/tests</directory>
+      </exclude>
       <directory>./modules</directory>
+      <exclude>
+        <directory>./modules/*/src/Tests</directory>
+        <directory>./modules/*/tests</directory>
+        <directory>./modules/*/*/src/Tests</directory>
+        <directory>./modules/*/*/tests</directory>
+      </exclude>
       <directory>./sites</directory>
       <!-- By definition test classes have no tests. -->
       <exclude>
         <directory suffix="Test.php">./</directory>
         <directory suffix="TestBase.php">./</directory>
       </exclude>
-     </whitelist>
+    </whitelist>
   </filter>
   <!-- Logging for coverage reports. -->
   <logging>

--- a/DEVELOPPING.md
+++ b/DEVELOPPING.md
@@ -29,6 +29,7 @@ Each version-directory is composed of a specific `Makefile` when the whole pull/
 Therefore, you can use those `Makefile` files to:
 
 * `build`: Build the image;
+* `build-nc`: Build the image without caches and pull the base image from remote;
 * `test`: Test the image;
 * `push`: Push the image on Docker hub;
 * `shell`: Run a shell inside the image for debugging;
@@ -66,3 +67,8 @@ Example to run the Drupal 9.0 tests-suits:
 ```shell
 cd ./9/9.0 && make build && make test
 ```
+
+You can also use the root `./update.sh [-t|--test=]` command to run the tests (useful for bulk tests):
+
+    ./update.sh --test=<8.8|9.0|all|latest>
+    ./update.sh -t

--- a/README.md
+++ b/README.md
@@ -118,5 +118,5 @@ before_script:
   - docker-compose exec -u www-data drupal drush site-install standard --db-url="mysql://drupal:drupal@db/drupal" --site-name=Example -y
 
 script:
-  - docker-compose exec -u www-data drupal phpunit --no-coverage --group=${MODULE_NAME}
+  - docker-compose exec -u www-data drupal phpunit --no-coverage --group=${MODULE_NAME} --configuration=/opt/drupal/web/phpunit.xml
 ```

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Overview:
           - 8888:80
         volumes:
           # Mount the module in the proper contrib module directory.
-          - .:/var/www/html/modules/contrib/my_module
+          - .:/opt/drupal/web/modules/contrib/my_module
         restart: always
     
       db:

--- a/examples/.travis.yml
+++ b/examples/.travis.yml
@@ -33,4 +33,4 @@ before_script:
   - docker-compose exec -u www-data drupal drush site-install standard --db-url="mysql://drupal:drupal@db/drupal" --site-name=Example -y
 
 script:
-  - docker-compose exec -u www-data drupal phpunit --no-coverage --group=${MODULE_NAME}
+  - docker-compose exec -u www-data drupal phpunit --no-coverage --group=${MODULE_NAME} --configuration=/opt/drupal/web/phpunit.xml

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -10,9 +10,9 @@ services:
       - 8888:80
     volumes:
       # Mount the module in the proper contrib module directory.
-      - .:/var/www/html/modules/contrib/my_module
+      - .:/opt/drupal/web/modules/contrib/my_module
       # Mount the Drupal PHPUnit configuration file.
-      - ./phpunit.xml:/var/www/html/phpunit.xml
+      - ./phpunit.xml:/opt/drupal/web/phpunit.xml
     restart: always
 
   db:

--- a/update.sh
+++ b/update.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-VERSION_TO_UPDATE="all"
 D8_LAST_VERSION=$(find ./8/* -maxdepth 1 -prune -type d -exec basename {} \; | sort -n | tail -n 1)
 D9_LAST_VERSION=$(find ./9/* -maxdepth 1 -prune -type d -exec basename {} \; | sort -n | tail -n 1)
 
@@ -26,7 +25,6 @@ while [ $# -gt 0 ]; do
       if [ "$1" = "--build" ] || [ "$1" = "-b" ]; then
         VERSION_TO_BUILD="all"
       fi
-      VERSION_TO_UPDATE=$VERSION_TO_BUILD
       ;;
     --publish=*)
       VERSION_TO_PUBLISH="${1#*=}"
@@ -35,7 +33,6 @@ while [ $# -gt 0 ]; do
         exit 1
       fi
       VERSION_TO_BUILD=$VERSION_TO_PUBLISH
-      VERSION_TO_UPDATE=$VERSION_TO_PUBLISH
       ;;
     -t|--test*)
       VERSION_TO_TEST="${1#*=}"

--- a/update.sh
+++ b/update.sh
@@ -15,8 +15,9 @@ while [ $# -gt 0 ]; do
        echo " "
        echo "options:"
        echo "-h, --help                show brief help"
-       echo "-b, --build=VERSION       VERSION is optional, all images are build by default; set a VERSION like '7.2-node8'"
-       echo "--publish=VERSION         set a VERSION like '7.2-node8' or 'all'; publish also build images"
+       echo "-b, --build=VERSION       VERSION is optional, all images are build by default; set a VERSION like 'drupal-9.1'"
+       echo "--publish=VERSION         set a VERSION like 'drupal-9.1' or 'all'; publish also build images"
+       echo "-t, --test=VERSION        VERSION is optional, all images are test by default; set a VERSION like 'drupal-9.1'; test also build images"
        echo "--clean                   clean all local tags of the image"
        exit 0
        ;;
@@ -35,6 +36,13 @@ while [ $# -gt 0 ]; do
       fi
       VERSION_TO_BUILD=$VERSION_TO_PUBLISH
       VERSION_TO_UPDATE=$VERSION_TO_PUBLISH
+      ;;
+    -t|--test*)
+      VERSION_TO_TEST="${1#*=}"
+      if [ "$1" = "--test" ] || [ "$1" = "-t" ]; then
+        VERSION_TO_TEST="all"
+      fi
+      VERSION_TO_BUILD=$VERSION_TO_TEST
       ;;
     --clean)
       if [ ! -z "$(docker images | grep wengerk/drupal-for-contrib | tr -s ' ' | cut -d ' ' -f 2 | grep -v '<none>')" ]; then
@@ -60,6 +68,17 @@ function build {
   )
 }
 
+function test {
+  (
+    set -e
+    TAG=$2
+
+    echo "** test wengerk/drupal-for-contrib:$TAG"
+    cd ./$1/$2/
+    [[ -f ./Makefile ]] && make test
+  )
+}
+
 function publish {
   (
     set -e
@@ -78,6 +97,11 @@ function process {
   # build docker image(s) if required.
   if [ "$VERSION_TO_BUILD" = "all" ] || [ "$VERSION_TO_BUILD" = "$drupalVersion" ]; then
       build $drupalMajorVersion $drupalVersion
+  fi
+
+  # test docker image(s) if required.
+  if [ "$VERSION_TO_TEST" = "all" ] || [ "$VERSION_TO_TEST" = "$drupalVersion" ]; then
+      test $drupalMajorVersion $drupalVersion
   fi
 
   # publish docker image(s) if required.


### PR DESCRIPTION
Update all images and apply new changes, especially since https://github.com/docker-library/drupal/issues/179 (Moving installation from `/var/www/html` to `/opt/drupal/web` that may caused breakage.)

A symlink has been made to keep backward compatiility, therefore `/var/www/html` link to `/opt/drupal/web`.

The `WORKDIR` has also been updated to `/opt/drupal` instead of `/var/www/html` to match Drupal parent image philosophy and make it easier to extend the image by being on the composer directory by default.

the change of `WORKDIR` will lead to an necessary update of every project using this image to run tests via phpunit.

It any modue/theme previously used `docker-compose exec -u www-data drupal phpunit --no-coverage --group=MODULE` they should now add `--configuration=/var/www/html/phpunit.xml` to ensure the proper phpunit file will be loaded.

Example_
```
docker-compose exec -u www-data drupal phpunit --no-coverage --group=${MODULE_NAME} --configuration=/var/www/html/phpunit.xml
```
