### PR TITLE
fix phpunit drupal 11.x+ undiscover tests on contrib sub-modules below ./modules

### DIFF
--- a/11/11.0/templates/phpunit.xml
+++ b/11/11.0/templates/phpunit.xml
@@ -78,21 +78,25 @@
   <testsuites>
     <testsuite name="unit">
       <directory>./modules/*/*/tests/src/Unit</directory>
+      <directory>./modules/*/*/modules/*/tests/src/Unit</directory>
       <directory>./profiles/*/*/tests/src/Unit</directory>
       <directory>./themes/*/*/tests/src/Unit</directory>
     </testsuite>
     <testsuite name="kernel">
       <directory>./modules/*/*/tests/src/Kernel</directory>
+      <directory>./modules/*/*/modules/*/tests/src/Kernel</directory>
       <directory>./profiles/*/*/tests/src/Kernel</directory>
       <directory>./themes/*/*/tests/src/Kernel</directory>
     </testsuite>
     <testsuite name="functional">
       <directory>./modules/*/*/tests/src/Functional</directory>
+      <directory>./modules/*/*/modules/*/tests/src/Functional</directory>
       <directory>./profiles/*/*/tests/src/Functional</directory>
       <directory>./themes/*/*/tests/src/Functional</directory>
     </testsuite>
     <testsuite name="functional-javascript">
       <directory>./modules/*/*/tests/src/FunctionalJavascript</directory>
+      <directory>./modules/*/*/modules/*/tests/src/FunctionalJavascript</directory>
       <directory>./profiles/*/*/tests/src/FunctionalJavascript</directory>
       <directory>./themes/*/*/tests/src/FunctionalJavascript</directory>
     </testsuite>

--- a/11/11.1/templates/phpunit.xml
+++ b/11/11.1/templates/phpunit.xml
@@ -78,21 +78,25 @@
   <testsuites>
     <testsuite name="unit">
       <directory>./modules/*/*/tests/src/Unit</directory>
+      <directory>./modules/*/*/modules/*/tests/src/Unit</directory>
       <directory>./profiles/*/*/tests/src/Unit</directory>
       <directory>./themes/*/*/tests/src/Unit</directory>
     </testsuite>
     <testsuite name="kernel">
       <directory>./modules/*/*/tests/src/Kernel</directory>
+      <directory>./modules/*/*/modules/*/tests/src/Kernel</directory>
       <directory>./profiles/*/*/tests/src/Kernel</directory>
       <directory>./themes/*/*/tests/src/Kernel</directory>
     </testsuite>
     <testsuite name="functional">
       <directory>./modules/*/*/tests/src/Functional</directory>
+      <directory>./modules/*/*/modules/*/tests/src/Functional</directory>
       <directory>./profiles/*/*/tests/src/Functional</directory>
       <directory>./themes/*/*/tests/src/Functional</directory>
     </testsuite>
     <testsuite name="functional-javascript">
       <directory>./modules/*/*/tests/src/FunctionalJavascript</directory>
+      <directory>./modules/*/*/modules/*/tests/src/FunctionalJavascript</directory>
       <directory>./profiles/*/*/tests/src/FunctionalJavascript</directory>
       <directory>./themes/*/*/tests/src/FunctionalJavascript</directory>
     </testsuite>

--- a/11/11.2/templates/phpunit.xml
+++ b/11/11.2/templates/phpunit.xml
@@ -78,21 +78,25 @@
   <testsuites>
     <testsuite name="unit">
       <directory>./modules/*/*/tests/src/Unit</directory>
+      <directory>./modules/*/*/modules/*/tests/src/Unit</directory>
       <directory>./profiles/*/*/tests/src/Unit</directory>
       <directory>./themes/*/*/tests/src/Unit</directory>
     </testsuite>
     <testsuite name="kernel">
       <directory>./modules/*/*/tests/src/Kernel</directory>
+      <directory>./modules/*/*/modules/*/tests/src/Kernel</directory>
       <directory>./profiles/*/*/tests/src/Kernel</directory>
       <directory>./themes/*/*/tests/src/Kernel</directory>
     </testsuite>
     <testsuite name="functional">
       <directory>./modules/*/*/tests/src/Functional</directory>
+      <directory>./modules/*/*/modules/*/tests/src/Functional</directory>
       <directory>./profiles/*/*/tests/src/Functional</directory>
       <directory>./themes/*/*/tests/src/Functional</directory>
     </testsuite>
     <testsuite name="functional-javascript">
       <directory>./modules/*/*/tests/src/FunctionalJavascript</directory>
+      <directory>./modules/*/*/modules/*/tests/src/FunctionalJavascript</directory>
       <directory>./profiles/*/*/tests/src/FunctionalJavascript</directory>
       <directory>./themes/*/*/tests/src/FunctionalJavascript</directory>
     </testsuite>


### PR DESCRIPTION
fix phpunit drupal 11.x+ undiscover tests on contrib sub-modules below ./modules